### PR TITLE
projects/example-sapphire-hardhat: Fix github URL typo

### DIFF
--- a/projects/demo-authzn/description.yaml
+++ b/projects/demo-authzn/description.yaml
@@ -5,6 +5,8 @@ authors:
 description: |
   A short demo which connects to the Oasis Authenticator and obtains the user
   ID stored on Sapphire, if the authentication is successful.
+paratimes:
+  - sapphire
 languages:
   - typescript
 license: Apache-2.0

--- a/projects/example-sapphire-hardhat/description.yaml
+++ b/projects/example-sapphire-hardhat/description.yaml
@@ -7,7 +7,7 @@ description: |
   confidential state to implement a [dead-man switch](https://en.wikipedia.org/wiki/Dead_man%27s_switch)
   app which stores a *secret ingredient*.
   
-  This example is part of the official [sapphire-paratime](https://github.com/oasisprotocol/sapphire)
+  This example is part of the official [sapphire-paratime](https://github.com/oasisprotocol/sapphire-paratime)
   codebase tests.
 paratimes:
   - sapphire


### PR DESCRIPTION
Fixes URL typo and the missing paratime field.