### PR TITLE
Display paratimes on project listing and popup

### DIFF
--- a/src/components/ProjectDialog.tsx
+++ b/src/components/ProjectDialog.tsx
@@ -90,40 +90,69 @@ const ProjectDialog: React.FC<ProjectDialogProps> = ({
                       </ReactMarkdown>
                       </Box>
 
-                      <Typography
-                      sx={{color: '#445E77', letterSpacing: '-0.5px', fontSize: '14px'}}
-                      >Last Updated: 
-                      </Typography>
-                      <Typography sx={{ color: '#3431AC', letterSpacing: '-0.5px', marginBottom: '16px' }}>
-                      <Typography component="span" sx={linkStyles}>
-                      { new Date(project.lastUpdated).toLocaleDateString()}
-                      </Typography>
-                    </Typography>
+                      <Grid container spacing={3}>
+                        <Grid item xs={6}>
+                          <Typography sx={{ color: '#445E77', letterSpacing: '-0.5px', fontSize: '14px' }}>
+                            Last Updated:
+                          </Typography>
+                          <Typography sx={{ color: '#3431AC', letterSpacing: '-0.5px', marginBottom: '16px' }}>
+                            <Typography component="span" sx={linkStyles}>
+                              {new Date(project.lastUpdated).toLocaleDateString()}
+                            </Typography>
+                          </Typography>
+                        </Grid>
 
-                    <Typography
-                      sx={{color: '#445E77', letterSpacing: '-0.5px', fontSize: '14px', marginTop: '16px'}}
-                      >Created: 
-                      </Typography>
-                      <Typography sx={{ color: '#3431AC', letterSpacing: '-0.5px', marginBottom: '24px' }}>
-                      <Typography component="span" sx={linkStyles}>
-                      {new Date(project.created).toLocaleDateString()}
-                      </Typography>
-                    </Typography>
+                        <Grid item xs={6}>
+                          <Typography sx={{ color: '#445E77', letterSpacing: '-0.5px', fontSize: '14px' }}>
+                            Created:
+                          </Typography>
+                          <Typography sx={{ color: '#3431AC', letterSpacing: '-0.5px', marginBottom: '24px' }}>
+                            <Typography component="span" sx={linkStyles}>
+                              {new Date(project.created).toLocaleDateString()}
+                            </Typography>
+                          </Typography>
+                        </Grid>
+                      </Grid>
 
-                    <Typography
-                      sx={{color: '#445E77', letterSpacing: '-0.5px', fontSize: '14px', marginTop: '16px'}}
-                      >Languages:
-                    </Typography>
-                    <Box sx={{ color: '#3431AC', letterSpacing: '-0.5px', marginBottom: '24px' }}>
-                    <ProjectItemLanguages langs={project.languages} selectedLangs={selectedLangs} isLarge={false} />
-                    </Box>
+                      <Grid container spacing={3}>
+                        <Grid item xs={6}>
+                          <Typography sx={{ color: '#445E77', letterSpacing: '-0.5px', fontSize: '14px', marginTop: '16px' }}>
+                            Languages:
+                          </Typography>
+                          <Box sx={{ color: '#3431AC', marginBottom: '24px' }}>
+                            <ProjectItemLanguages langs={project.languages} selectedLangs={selectedLangs} isLarge={false} />
+                          </Box>
+                        </Grid>
 
-                    <Typography
-                      sx={{color: '#445E77', letterSpacing: '-0.5px', fontSize: '14px', marginTop: '16px', marginBottom: '6px'}}
-                      >Tags:
-                    </Typography>
-                    <ProjectItemTags tags={project.tags} selectedTags={selectedTags} isLarge={true} />
-                   
+                        <Grid item xs={6}>
+                          <Typography sx={{ color: '#445E77', letterSpacing: '-0.5px', fontSize: '14px', marginTop: '16px' }}>
+                            ParaTimes:
+                          </Typography>
+                          <Box sx={{ color: '#3431AC', marginBottom: '24px' }}>
+                            <Typography component="span">
+                            {project.paratimes.map((paratime: string, index: number) => (
+                              <Typography
+                                component="span"
+                                key={paratime}
+                                sx={{letterSpacing: '-0.03em'}}
+                              >
+                                {paratime.charAt(0).toUpperCase() + paratime.slice(1)}
+                                {index < project.paratimes.length - 1 && ', '}
+                              </Typography>
+                            ))}
+                            </Typography>
+                          </Box>
+                        </Grid>
+                      </Grid>
+
+                      <Grid container spacing={3}>
+                        <Grid item xs={12}>
+                          <Typography sx={{ color: '#445E77', letterSpacing: '-0.5px', fontSize: '14px', marginTop: '16px', marginBottom: '6px' }}>
+                            Tags:
+                          </Typography>
+                          <ProjectItemTags tags={project.tags} selectedTags={selectedTags} isLarge={true} />
+                        </Grid>
+                      </Grid>
                    </Grid>
                    <Grid item xs={12} md={6}>
                      <Typography

--- a/src/components/ProjectItemLanguages.tsx
+++ b/src/components/ProjectItemLanguages.tsx
@@ -1,4 +1,4 @@
-import { Typography, Box } from '@mui/material';
+import { Typography, Box, useTheme, useMediaQuery } from '@mui/material';
 
 interface ProjectItemLanguagesProps {
   langs: string[];
@@ -7,12 +7,19 @@ interface ProjectItemLanguagesProps {
   isInListItem?: boolean;
 }
 
-const LanguagesList: React.FC<ProjectItemLanguagesProps> = ({ langs, selectedLangs, isLarge, isInListItem }) => {
 
+
+const LanguagesList: React.FC<ProjectItemLanguagesProps> = ({ langs, selectedLangs, isLarge, isInListItem }) => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  
   return (
     <Box
       sx={{
-        borderTop: isInListItem ? '1px solid #3431AC': 'none'
+        borderBottom: isInListItem ? '1px solid #3431AC': 'none',
+        paddingBottom: '2px',
+        paddingTop: isMobile ? '12px' : '0'
+        
       }}
     >
       {langs.map((lang: string, index: number) => (

--- a/src/components/ProjectListItem.tsx
+++ b/src/components/ProjectListItem.tsx
@@ -28,7 +28,6 @@ const ProjectListItem: React.FC<ProjectListItemProps> = ({
 }) => {
   const theme = useTheme();
   const isMobileScreen = useMediaQuery(theme.breakpoints.down('sm'));
-
   
   return (
     <Grid item xs={12} sm={6} md={4}>
@@ -98,9 +97,30 @@ const ProjectListItem: React.FC<ProjectListItemProps> = ({
                 />
               )}
             </Grid> 
-            <Grid item xs={12} >
+
+            <Box sx={{display: 'block', width: '100%', paddingLeft: '16px'}}>
               <ProjectItemLanguages langs={langs} selectedLangs={selectedLangs} isLarge={false} isInListItem={true} />
-            </Grid>
+            </Box>
+
+            <Box sx={{display: 'block', width: '100%', paddingLeft: '16px', paddingTop: '2px'}}>
+            <Typography sx={{
+              color: '#445E77',
+              fontSize: '14px'
+              }}>
+                {/* ParaTimes: {' '} */}
+                {project.paratimes.map((paratime: string, index: number) => (
+                  <Typography
+                    component="span"
+                    key={paratime}
+                    sx={{letterSpacing: '-0.03em', color: '#445E77',
+                    fontSize: '14px'}}
+                  >
+                    {paratime.charAt(0).toUpperCase() + paratime.slice(1)}
+                    {index < project.paratimes.length - 1 && ', '}
+                  </Typography>
+                ))}
+                </Typography>
+            </Box>
             
           </Grid>
         </Box>


### PR DESCRIPTION
**Before:**
<img width="315" alt="Screenshot 2024-01-30 at 12 38 16" src="https://github.com/oasisprotocol/playground/assets/52677556/8a4c83ae-4c28-4198-9433-9d1b8ed3773f">
<img width="690" alt="Screenshot 2024-01-30 at 12 38 34" src="https://github.com/oasisprotocol/playground/assets/52677556/9d890608-21e2-43c2-97b8-a1294229a4a4">

**After:**
<img width="301" alt="Screenshot 2024-01-30 at 12 39 25" src="https://github.com/oasisprotocol/playground/assets/52677556/25bf0a86-fcc7-40f9-aecf-246806354a80">
<img width="680" alt="Screenshot 2024-01-30 at 12 39 45" src="https://github.com/oasisprotocol/playground/assets/52677556/2a9fa0df-7597-4953-93df-cb996b8f5046">

