### PR TITLE
Set main background size to auto

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ const paddingValue = isMobile ? '42px' : '80px';
       height: '100%',
       minHeight: '100vh',
       backgroundImage: `url(${backgroundImg})`,
-      backgroundSize: 'contain',
+      backgroundSize: 'auto',
       backgroundRepeat: 'no-repeat',
       backgroundColor: '#1421F8',
     }}>


### PR DESCRIPTION
Set the size of the main background to 'auto' to fit the screen width, even when there are fewer cards in the projects list.

Before:
<img width="1671" alt="Screenshot 2024-01-30 at 13 51 55" src="https://github.com/oasisprotocol/playground/assets/52677556/6ba47021-3414-4910-aff3-a5753b5edf33">

After:
<img width="1676" alt="Screenshot 2024-01-30 at 13 53 16" src="https://github.com/oasisprotocol/playground/assets/52677556/c633f327-1434-4a46-80eb-1114f5e7a508">
