### PR TITLE
Fix screenshots after switching projects

### DIFF
--- a/src/components/ProjectDialog.tsx
+++ b/src/components/ProjectDialog.tsx
@@ -4,7 +4,7 @@ import { Close } from '@mui/icons-material';
 import ProjectItemTags from './ProjectItemTags';
 import { Project } from '../types';
 import Carousel from 'react-bootstrap/Carousel';
-import { SetStateAction, useState } from 'react';
+import { SetStateAction, useEffect, useState } from 'react';
 import MaintainedByOasisIcon from '../assets/MaintainedByOasisIcon.svg';
 import '../App.css'; 
 import { useTheme } from '@mui/material/styles';
@@ -38,6 +38,11 @@ const ProjectDialog: React.FC<ProjectDialogProps> = ({
   const [carouselIndex, setCarouselIndex] = useState(0);
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
+  useEffect(() => {
+    // Reset state after switching projects
+    setCarouselIndex(0)
+  }, [project])
 
   const handleSelectCarouselSlide = (selectedIndex: SetStateAction<number>) => {
     setCarouselIndex(selectedIndex);


### PR DESCRIPTION
Before:
- open 0x2FA project
- switch to second screenshot
- close and open Authenticator Demo project
- see broken carousel for 5 seconds

![playground oasis io_](https://github.com/oasisprotocol/playground/assets/3758846/5f4c4551-a844-43f3-b35a-449f36ebe95f)
