### PR TITLE
Add tag filtering inside of projects

### DIFF
--- a/src/components/ProjectDialog.tsx
+++ b/src/components/ProjectDialog.tsx
@@ -34,6 +34,7 @@ const ProjectDialog: React.FC<ProjectDialogProps> = ({
   project,
   selectedTags,
   selectedLangs,
+  handleTagClick
 }) => {
   const [carouselIndex, setCarouselIndex] = useState(0);
   const theme = useTheme();
@@ -103,9 +104,9 @@ const ProjectDialog: React.FC<ProjectDialogProps> = ({
                       <Box
                           sx={{color: '#000000', letterSpacing: '-0.5px', marginBottom: '24px', fontFamily: "'Roboto Flex Variable',sans-serif"}}
                           >
-                             <ReactMarkdown components={{ a: ({ node, ...props }) => modifyLinkTarget(props.href, props.title, props.children) }}>
-                              {project.description}
-                            </ReactMarkdown>
+                             <ReactMarkdown components={{ a: (props) => modifyLinkTarget(props.href, props.title, props.children) }}>
+                                {project.description}
+                             </ReactMarkdown>
                       </Box>
 
                       <Grid container spacing={3}>
@@ -168,7 +169,7 @@ const ProjectDialog: React.FC<ProjectDialogProps> = ({
                           <Typography sx={{ color: '#000000', letterSpacing: '-0.5px', fontSize: '14px', marginTop: '16px', marginBottom: '6px' }}>
                             Tags:
                           </Typography>
-                          <ProjectItemTags tags={project.tags} selectedTags={selectedTags} isLarge={false} />
+                          <ProjectItemTags tags={project.tags} selectedTags={selectedTags} isLarge={false} handleTagClick={handleTagClick}/>
                         </Grid>
                       </Grid>
                    </Grid>

--- a/src/components/ProjectItemTags.tsx
+++ b/src/components/ProjectItemTags.tsx
@@ -4,9 +4,10 @@ interface ProjectItemTagsProps {
   tags: string[];
   selectedTags: string[];
   isLarge: boolean;
+  handleTagClick: (tag: string) => void;
 }
 
-const ProjectItemTags: React.FC<ProjectItemTagsProps> = ({ tags, selectedTags, isLarge }) => {
+const ProjectItemTags: React.FC<ProjectItemTagsProps> = ({ tags, selectedTags, isLarge, handleTagClick }) => {
   return (
     <div>
       {tags.map((tag: string) => (
@@ -14,11 +15,15 @@ const ProjectItemTags: React.FC<ProjectItemTagsProps> = ({ tags, selectedTags, i
             label={tag}
             key={tag}
             color={selectedTags.includes(tag) ? 'primary' : 'default'}
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              handleTagClick(tag);
+            }}
             sx={{
               marginRight: '4px',
               height: 'auto',
               fontSize: '14px',
-              cursor: 'auto',
               '& .MuiChip-label': {
                 padding: '4px 14px',  
                 fontWeight: '400',

--- a/src/components/ProjectListItem.tsx
+++ b/src/components/ProjectListItem.tsx
@@ -25,7 +25,8 @@ const ProjectListItem: React.FC<ProjectListItemProps> = ({
   selectedTags,
   selectedLangs,
   tags,
-  langs
+  langs,
+  handleTagClick
 }) => {
   const theme = useTheme();
   const isMobileScreen = useMediaQuery(theme.breakpoints.down('sm'));
@@ -84,7 +85,7 @@ const ProjectListItem: React.FC<ProjectListItemProps> = ({
               </Box>
 
               <Box sx={{ minHeight: isMobileScreen ? '50px' : '80px', marginTop: '24px' }}>
-                  <ProjectItemTags tags={tags} selectedTags={selectedTags} isLarge={false} />
+                  <ProjectItemTags tags={tags} selectedTags={selectedTags} isLarge={false} handleTagClick={handleTagClick}/>
               </Box>
             </Grid>
 


### PR DESCRIPTION
Adding functionality that lets users filter projects by clicking on tags directly within the project items. When you click a tag, it automatically triggers the filter, and the selected tags will be reflected in the filter area. 

Before:
<img width="1680" alt="Screenshot 2024-08-26 at 13 36 13" src="https://github.com/user-attachments/assets/b139eb3f-e60c-410e-8c23-d8c844c70480">

After:
<img width="1679" alt="Screenshot 2024-08-26 at 13 36 50" src="https://github.com/user-attachments/assets/debfcf11-e826-4c89-ac41-597cfd4d23a4">
