### PR TITLE
Fall back rule for line clamp for old safari version.

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -64,6 +64,8 @@ button:focus-visible {
   -webkit-line-clamp: 3;
   line-clamp: 3;
   -webkit-box-orient: vertical;
+  /* Fallback for old iOS Safari */
+  max-height: 3.9em;
 }
 
 .markdown-line-clamp p {


### PR DESCRIPTION
Added a maximum height as a fallback to the line clamp rule on project card descriptions for layout consistency in older versions of iOS Safari.

Reported Issue:
https://github.com/user-attachments/assets/296f0966-fc7a-4ff5-94e0-16a9f506cc10

Expected behavior:
<img width="364" alt="Screenshot 2024-09-10 at 15 33 22" src="https://github.com/user-attachments/assets/c886e2d6-4eed-4fbf-a155-5fad3995a80c">
