### PR TITLE
Keep hash on url rewrite

### DIFF
--- a/src/components/ProjectList.tsx
+++ b/src/components/ProjectList.tsx
@@ -66,7 +66,8 @@ const ProjectList: React.FC = () => {
     if (selectedSources.length) params.set('sources', selectedSources.join(','));
     if (selectedParatimes.length) params.set('paratimes', selectedParatimes.join(','));
 
-    navigate(`?${params.toString()}`, { replace: true });
+    const currentHash = location.hash;
+    navigate(`?${params.toString()}${currentHash}`, { replace: true });
   }, [
     search,
     selectedTags,


### PR DESCRIPTION
From FE Sync
Fixes https://github.com/oasisprotocol/playground/issues/96

Looks like we get selected project here https://github.com/oasisprotocol/playground/blob/main/src/components/ProjectList.tsx#L27, but in a next render cycle when useEffect triggers, hash is removed here https://github.com/oasisprotocol/playground/blob/main/src/components/ProjectList.tsx#L69

@kaja-osojnik can you test the fix please? I am not familiar with playground. 
