### PR TITLE
Fix typos in project descriptions

### DIFF
--- a/projects/clpd-private/description.yaml
+++ b/projects/clpd-private/description.yaml
@@ -75,7 +75,7 @@ description: |
   CLPD Token: [View on
   Explorer](https://basescan.org/token/0x24460D2b3d96ee5Ce87EE401b1cf2FD01545d9b1)
 
-  [See a demo video of how to aquire some
+  [See a demo video of how to acquire some
   CLPD](https://www.youtube.com/watch?v=m3C15BdIzVM&t=2s&ab_channel=DanielBeltr%C3%A1nVaras)
 
   Check out more on the hackathon's [project

--- a/projects/demo-e2eproxy/description.yaml
+++ b/projects/demo-e2eproxy/description.yaml
@@ -5,7 +5,7 @@ authors:
 description: |
   A short example of how a contract can relay an end-to-end encrypted
   transactions on Oasis Sapphire, so the relayer cannot see which contract is
-  being invoked or what the parameters are. This is usefull for services such
+  being invoked or what the parameters are. This is useful for services such
   as the gas station network or other gasless services.
 
   By using the [@oasis-protocol/sapphire-contracts](https://www.npmjs.com/package/@oasisprotocol/sapphire-contracts)


### PR DESCRIPTION
This PR fixes the following typos in YAML description files:
- Corrects "aquire" to "acquire" in clpd-private/description.yaml
- Corrects "usefull" to "useful" in demo-e2eproxy/description.yaml